### PR TITLE
(down) "gforge.org" to (up) "gforgegroup.com"

### DIFF
--- a/cli/include/CLI_Action.class.php
+++ b/cli/include/CLI_Action.class.php
@@ -149,7 +149,7 @@ class CLI_Action {
      * extracted from GForge Command-line Interface
      * contained in GForge.
      * Copyright 2005 GForge, LLC
-     * http://gforge.org/
+     * https://gforgegroup.com/
      *
      * @param    array    Result of a SOAP call
      * @param    array    Titles to assign to each field (optional).
@@ -356,7 +356,7 @@ class CLI_Action {
      * extracted from GForge Command-line Interface
      * contained in GForge.
      * Copyright 2005 GForge, LLC
-     * http://gforge.org/
+     * https://gforgegroup.com/
      *
      */
     function show_scalar($result, $fieldnames = array()) {
@@ -380,7 +380,7 @@ class CLI_Action {
      * extracted from GForge Command-line Interface
      * contained in GForge.
      * Copyright 2005 GForge, LLC
-     * http://gforge.org/
+     * https://gforgegroup.com/
      *
      */
     function show_vector($result, $fieldnames = array()) {
@@ -424,7 +424,7 @@ class CLI_Action {
      * extracted from GForge Command-line Interface
      * contained in GForge.
      * Copyright 2005 GForge, LLC
-     * http://gforge.org/
+     * https://gforgegroup.com/
      *
      */
     function show_matrix($result, $fieldnames = array()) {
@@ -543,7 +543,7 @@ class CLI_Action {
      * extracted from GForge Command-line Interface
      * contained in GForge.
      * Copyright 2005 GForge, LLC
-     * http://gforge.org/
+     * https://gforgegroup.com/
      *
      * @param    string
      * @param    int
@@ -562,7 +562,7 @@ class CLI_Action {
      * extracted from GForge Command-line Interface
      * contained in GForge.
      * Copyright 2005 GForge, LLC
-     * http://gforge.org/
+     * https://gforgegroup.com/
      *
      * @param    string    UNIX name of the project
      */
@@ -593,7 +593,7 @@ class CLI_Action {
      * extracted from GForge Command-line Interface
      * contained in GForge.
      * Copyright 2005 GForge, LLC
-     * http://gforge.org/
+     * https://gforgegroup.com/
      *
      * @param array An array of parameters to look for the defined group. If the group isn't in the parameters, looks in the session
      * @param bool Specify if we should abort the program if the group isn't found
@@ -621,7 +621,7 @@ class CLI_Action {
      * extracted from GForge Command-line Interface
      * contained in GForge.
      * Copyright 2005 GForge, LLC
-     * http://gforge.org/
+     * https://gforgegroup.com/
      *
      * @param    string    Date
      * @return    string    String with the error (if any)
@@ -650,7 +650,7 @@ class CLI_Action {
      * extracted from GForge Command-line Interface
      * contained in GForge.
      * Copyright 2005 GForge, LLC
-     * http://gforge.org/
+     * https://gforgegroup.com/
      *
      * This function assumes the date has the correct format
      * @param    string    Date

--- a/cli/include/CLI_Module.class.php
+++ b/cli/include/CLI_Module.class.php
@@ -58,7 +58,7 @@ class CLI_Module {
      * extracted from GForge Command-line Interface
      * contained in GForge.
      * Copyright 2005 GForge, LLC
-     * http://gforge.org/
+     * https://gforgegroup.com/
      *
      * Given an array of parameters passed by the command line, this function
      * searches the specified parameter in that array.
@@ -157,7 +157,7 @@ class CLI_Module {
      * extracted from GForge Command-line Interface
      * contained in GForge.
      * Copyright 2005 GForge, LLC
-     * http://gforge.org/
+     * https://gforgegroup.com/
      *
      * @param string Text to show to the user
      * @param bool Specify if input shouldn't be shown (useful when asking for passwords)

--- a/cli/include/CodendiSOAP.class.php
+++ b/cli/include/CodendiSOAP.class.php
@@ -3,7 +3,7 @@
  * Portion of this file is inspired from the  GForge Command-line Interface
  * contained in GForge.
  * Copyright 2005 GForge, LLC
- * http://gforge.org/
+ * https://gforgegroup.com/
  *
  *
  */

--- a/cli/include/Log.class.php
+++ b/cli/include/Log.class.php
@@ -5,7 +5,7 @@
  * Portion of this file is inspired from the  GForge Command-line Interface
  * contained in GForge.
  * Copyright 2005 GForge, LLC
- * http://gforge.org/
+ * https://gforgegroup.com/
  *
  */
 

--- a/cli/include/common.php
+++ b/cli/include/common.php
@@ -5,7 +5,7 @@
  * Portion of this file is inspired from the  GForge Command-line Interface
  * contained in GForge.
  * Copyright 2005 GForge, LLC
- * http://gforge.org/
+ * https://gforgegroup.com/
  *
  */
 

--- a/cli/include/modules/default/default.php
+++ b/cli/include/modules/default/default.php
@@ -5,7 +5,7 @@
  * Portion of this file is inspired from the  GForge Command-line Interface
  * contained in GForge.
  * Copyright 2005 GForge, LLC
- * http://gforge.org/
+ * https://gforgegroup.com/
  *
  */
 

--- a/cli/include/modules/docman/docman.php
+++ b/cli/include/modules/docman/docman.php
@@ -5,7 +5,7 @@
  * Portion of this file is inspired from the  GForge Command-line Interface
  * contained in GForge.
  * Copyright 2005 GForge, LLC
- * http://gforge.org/
+ * https://gforgegroup.com/
  *
  */
 

--- a/cli/include/modules/frs/frs.php
+++ b/cli/include/modules/frs/frs.php
@@ -5,7 +5,7 @@
  * Portion of this file is inspired from the  GForge Command-line Interface
  * contained in GForge.
  * Copyright 2005 GForge, LLC
- * http://gforge.org/
+ * https://gforgegroup.com/
  *
  */
 

--- a/cli/include/modules/tracker/tracker.php
+++ b/cli/include/modules/tracker/tracker.php
@@ -5,7 +5,7 @@
  * Portion of this file is inspired from the  GForge Command-line Interface
  * contained in GForge.
  * Copyright 2005 GForge, LLC
- * http://gforge.org/
+ * https://gforgegroup.com/
  *
  */
 require_once(CODENDI_CLI_DIR.'/CLI_Module.class.php');
@@ -95,7 +95,7 @@ class CLI_Module_Tracker extends CLI_Module {
      * extracted from GForge Command-line Interface
      * contained in GForge.
      * Copyright 2005 GForge, LLC
-     * http://gforge.org/
+     * https://gforgegroup.com/
      *
      * As there are standard and custom fields, we assume that every parameter other than
      * 'tracker', 'group_id', 'project' is a field name.
@@ -144,7 +144,7 @@ class CLI_Module_Tracker extends CLI_Module {
      * extracted from GForge Command-line Interface
      * contained in GForge.
      * Copyright 2005 GForge, LLC
-     * http://gforge.org/
+     * https://gforgegroup.com/
      *
      * As there are standard and custom fields, we assume that every parameter other than
      * 'tracker', 'group_id', 'project' is a field name.

--- a/cli/tuleap.php
+++ b/cli/tuleap.php
@@ -1,7 +1,7 @@
 #!/usr/bin/php -q
 <?php
 /**
- * Copyright 2005 GForge, LLC http://gforge.org/
+ * Copyright 2005 GForge, LLC https://gforgegroup.com/
  * Copyright Xerox Corporation, Codendi Team, 2009. All rights reserved
  * Copyright (c) Enalean, 2013. All Rights Reserved.
  *

--- a/documentation/cli/xml/en_US/BookInfo.xml
+++ b/documentation/cli/xml/en_US/BookInfo.xml
@@ -60,7 +60,7 @@
 
       <para>Portion of this documentation is inspired from the  GForge Command-line Interface documentation contained in GForge.</para>
       <para>Copyright 2005 GForge, LLC</para>
-      <para>http://gforge.org/</para>
+      <para>https://gforgegroup.com/</para>
 
       <para>Xerox ®, The Document Company ®, and all Xerox products mentioned
       in this publication are trademarks of Xerox Corporation.</para>

--- a/documentation/cli/xml/en_US/Installation.xml
+++ b/documentation/cli/xml/en_US/Installation.xml
@@ -3,7 +3,7 @@
 // Portion of this file is inspired from the  GForge Command-line Interface
 // contained in GForge.
 // Copyright 2005 GForge, LLC
-// http://gforge.org/
+// https://gforgegroup.com/
 //
 //
 // Written by Marc Nazarian 2006, Codendi Team, Xerox

--- a/documentation/cli/xml/en_US/Modules.xml
+++ b/documentation/cli/xml/en_US/Modules.xml
@@ -3,7 +3,7 @@
 // Portion of this file is inspired from the  GForge Command-line Interface
 // contained in GForge.
 // Copyright 2005 GForge, LLC
-// http://gforge.org/
+// https://gforgegroup.com/
 //
 //
 // Written by Marc Nazarian 2006, Codendi Team, Xerox

--- a/documentation/cli/xml/en_US/Usage.xml
+++ b/documentation/cli/xml/en_US/Usage.xml
@@ -3,7 +3,7 @@
 // Portion of this file is inspired from the  GForge Command-line Interface
 // contained in GForge.
 // Copyright 2005 GForge, LLC
-// http://gforge.org/
+// https://gforgegroup.com/
 // 
 //
 // Written by Marc Nazarian 2006, Codendi Team, Xerox

--- a/documentation/cli/xml/fr_FR/BookInfo.xml
+++ b/documentation/cli/xml/fr_FR/BookInfo.xml
@@ -60,7 +60,7 @@
 
       <para>Portion of this documentation is inspired from the  GForge Command-line Interface documentation contained in GForge.</para>
       <para>Copyright 2005 GForge, LLC</para>
-      <para>http://gforge.org/</para>
+      <para>https://gforgegroup.com/</para>
 
       <para>Xerox ®, The Document Company ®, and all Xerox products mentioned
       in this publication are trademarks of Xerox Corporation.</para>

--- a/documentation/cli/xml/fr_FR/Installation.xml
+++ b/documentation/cli/xml/fr_FR/Installation.xml
@@ -4,7 +4,7 @@
 // Portion of this file is inspired from the  GForge Command-line Interface
 // contained in GForge.
 // Copyright 2005 GForge, LLC
-// http://gforge.org/
+// https://gforgegroup.com/
 //
 //
 // Written by Marc Nazarian 2006, Codendi Team, Xerox

--- a/documentation/cli/xml/fr_FR/Modules.xml
+++ b/documentation/cli/xml/fr_FR/Modules.xml
@@ -4,7 +4,7 @@
 // Portion of this file is inspired from the  GForge Command-line Interface
 // contained in GForge.
 // Copyright 2005 GForge, LLC
-// http://gforge.org/
+// https://gforgegroup.com/
 //
 //
 // Written by Marc Nazarian 2006, Codendi Team, Xerox

--- a/documentation/cli/xml/fr_FR/Usage.xml
+++ b/documentation/cli/xml/fr_FR/Usage.xml
@@ -4,7 +4,7 @@
 // Portion of this file is inspired from the  GForge Command-line Interface
 // contained in GForge.
 // Copyright 2005 GForge, LLC
-// http://gforge.org/
+// https://gforgegroup.com/
 //
 //
 // Written by Marc Nazarian 2006, Codendi Team, Xerox

--- a/plugins/docman/bin/DocmanImport/parameters.php
+++ b/plugins/docman/bin/DocmanImport/parameters.php
@@ -5,7 +5,7 @@
  * extracted from GForge Command-line Interface
  * contained in GForge.
  * Copyright 2005 GForge, LLC
- * http://gforge.org/
+ * https://gforgegroup.com/
  *
  * Given an array of parameters passed by the command line, this function
  * searches the specified parameter in that array.


### PR DESCRIPTION
I figured out that gforge.org was down.
So I changed for the new domain.
Source : https://blog.gforgegroup.com/2012/01/04/gforge-as-2012/