### PR TITLE
Fix Bearer nomenclature in OAuth2 access token success representation

### DIFF
--- a/src/common/OAuth2ServerCore/Grant/OAuth2AccessTokenSuccessfulRequestRepresentation.php
+++ b/src/common/OAuth2ServerCore/Grant/OAuth2AccessTokenSuccessfulRequestRepresentation.php
@@ -94,7 +94,7 @@ final class OAuth2AccessTokenSuccessfulRequestRepresentation implements \JsonSer
     public function jsonSerialize(): array
     {
         $json_encoded = [
-            'token_type'   => 'bearer',
+            'token_type'   => 'Bearer',
             'access_token' => $this->access_token->getString(),
             'expires_in'   => $this->expires_in,
         ];


### PR DESCRIPTION
Fix the representation of the OAuth2 access token endpoint returns on success, _token_type_ is currently "**bearer**" but the OAuth spec says we have to write "**Bearer**" with a capital B because it's insensitive.

Ref in the specific endpoint: https://www.oauth.com/oauth2-servers/access-tokens/access-token-response/
Authorization header specification : https://www.rfc-editor.org/rfc/rfc6750#section-2.1
 