### PR TITLE
bugfix: updated mediawiki php-fpm to 81

### DIFF
--- a/tools/docker/tuleap-aio-c7/supervisor.d/start-mediawiki-php-fpm.sh
+++ b/tools/docker/tuleap-aio-c7/supervisor.d/start-mediawiki-php-fpm.sh
@@ -1,3 +1,3 @@
 #! /usr/bin/env bash
 
-exec env -i PATH="$PATH" /opt/remi/php74/root/usr/sbin/php-fpm --nodaemonize --fpm-config /usr/share/tuleap/plugins/mediawiki_standalone/etc/php-fpm/mediawiki-tuleap.conf
+exec env -i PATH="$PATH" /opt/remi/php81/root/usr/sbin/php-fpm --nodaemonize --fpm-config /usr/share/tuleap/plugins/mediawiki_standalone/etc/php-fpm/mediawiki-tuleap.conf


### PR DESCRIPTION
After upgrading to the latest tuleap community docker container it would no longer start.
`supervisord` was reporting
```
2024-01-01 00:23:09,747 INFO exited: php-fpm (exit status 127; not expected)
```
and after investigating I found that PHP 7.4 was removed (in favor of 8.1) but the supervisor script for mediawiki was still referencing the old php-fpm version.
This pull request fixes this. The container now starts and runs ok.